### PR TITLE
bump react-router version and add react-bootstrap version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,12 +41,14 @@
     "morgan": "^1.5.1",
     "react": "^0.13.x",
     "react-document-title": "^1.0.2",
-    "react-router": "^0.11.x",
+    "react-router": "^0.13.x",
     "reflux": "^0.2.5",
     "run-sequence": "^0.3.6",
     "superagent": "^0.21.0",
     "vinyl-source-stream": "^0.1.1",
     "watchify": "^2.4.x",
-    "when": "^3.7.2"
-  }
+    "when": "^3.7.2",
+    "react-bootstrap": "^0.23.5"
+  },
+  "dependencies": {}
 }


### PR DESCRIPTION
I had to bump the version of `react-router` in order for `npm install`
to complete successfully.
Also added `react-bootstrap` in package.json.
After running `gulp dev`, things seem to be working.